### PR TITLE
CWE-116999: CC jenkins plugin should not display an IOException in th…

### DIFF
--- a/src/main/java/com/compuware/jenkins/build/CodeCoverageScanner.java
+++ b/src/main/java/com/compuware/jenkins/build/CodeCoverageScanner.java
@@ -218,9 +218,10 @@ public class CodeCoverageScanner
 		}
 		catch (IOException e)
 		{
-			logger.println("An IOException occurred while obtaining analysis properties from the file: " + e.toString()); //$NON-NLS-1$
+			// An error should be displayed only if an analysis file was specified in the configuration.
 			if (filePathSpecified)
 			{
+				logger.println("An IOException occurred while obtaining analysis properties from the file: " + e.toString()); //$NON-NLS-1$
 				e.printStackTrace(logger);
 			}
 		}


### PR DESCRIPTION
…e log when the ccanalysis.properties file is not defined and there are properties defined in the analysis properties text field

https://agile.compuware.com/browse/CWE-116999